### PR TITLE
_maxCount parameter addition

### DIFF
--- a/FHIR-data-migration-tool-docs/README.md
+++ b/FHIR-data-migration-tool-docs/README.md
@@ -360,6 +360,38 @@ Name: AZURE_ChunkLimit
 Value: 100000000
 ```
 
+By default, the migration tool exports have _maxCount per job to 10000, which is configurable by using parameters: MaxCount, MaxCountValue of data from API for FHIR in each export operation.
+
+#### How to configure MaxCount and MaxCountValue for export
+1. After deploying, open the Data migration Azure function.
+2. Go to the environment variable setting and under it go to App Setting.
+3. Set the below configuration as per the need:
+```
+Name: AZURE_MaxCount
+Value: true or false
+
+Name: AZURE_MaxCountValue
+Value: <<Int number>>
+
+```
+AZURE_MaxCount can be set to true or false. This parameter allows you to modify the migration tool to use the specified _maxCount value.
+- If set to false, the export job will default to a value of 10,000 for _maxCount.
+- If set to true, it enables you to change the _maxCount value to address issues encountered during the export job.
+
+AZURE_MaxCountValue will take integer as value.   
+
+Example:
+
+Below setting in Azure Function for export allowing the _maxCount parameter in export query with value 5000 in a single chunk: 
+```
+Name: AZURE_MaxCount
+Value: true
+
+Name: AZURE_MaxCountValue
+Value: 5000
+
+```
+
 You  can configure the start date in Azure function from where the export should start from the API for FHIR server. AZURE_StartDate will help to export the data from that specific date. <br>
 If the start date is not provided the tool will fetch the first resource date from the server and start the migration.
 
@@ -516,6 +548,11 @@ There are two table storages created during deployment.
 4. To troubleshoot the error or failure of export-import. 
 	- Please check the export table storage created during deployment process linked to Azure function app.
 		- It contain the details for each export-import error status.
+		- If the export failed due to : "The FHIR Server ran out of memory while processing an export job. Please use the _maxCount parameter when requesting an export job to reduce the number of resources exported at one time. The count used in this job was 10000"<br>
+			Resolution:
+			- Reduce the _maxCount per export job by following the steps outlined in the Export section of the migration tool documentation.
+			- Refer to the "How to configure MaxCount and MaxCountValue for export" section for detailed instructions on adjusting these parameters.<br>
+	By reducing the _maxCount, you can prevent memory-related issues during the export process.
 	- Please check the details of export-import failure on dashboard as well
 		- Export failure details can be found in Failed Export details 
 		- Import failure details can be found in Failed Import details 

--- a/infra/azureFunction.bicep
+++ b/infra/azureFunction.bicep
@@ -127,6 +127,8 @@ resource functionApp 'Microsoft.Web/sites@2021-03-01' = {
               AZURE_ExportWithHistory: exportWithHistory
               AZURE_ExportWithDelete: exportWithDelete
               AZURE_IsParallel:isParallel
+              AZURE_MaxCount: 'false'
+              AZURE_MaxCountValue: 10000
               AZURE_ExportDeidentified:exportDeidentified
               AZURE_StopDm:stopDm
               AZURE_StartTime:startTime

--- a/infra/main.json
+++ b/infra/main.json
@@ -344,7 +344,7 @@
             "name": "[format('{0}/{1}', variables('functionAppName'), 'web')]",
             "properties": {
                 "repoUrl": "[variables('repoUrl')]",
-                "branch": "personal/v-shnarang/maxcount",
+                "branch": "main",
                 "isManualIntegration": true
             },
             "dependsOn": [

--- a/infra/main.json
+++ b/infra/main.json
@@ -317,6 +317,8 @@
                 "AZURE_ExportWithHistory": "[parameters('exportWithHistory')]",
                 "AZURE_ExportWithDelete": "[parameters('exportWithDelete')]",
                 "AZURE_IsParallel": "[parameters('isParallel')]",
+                "AZURE_MaxCount": false,
+                "AZURE_MaxCountValue": 10000,
                 "AZURE_ExportDeidentified":"[parameters('exportDeidentified')]",
                 "AZURE_StopDm":"[parameters('stopDm')]",
                 "AZURE_StartTime":"[parameters('startTime')]",
@@ -342,7 +344,7 @@
             "name": "[format('{0}/{1}', variables('functionAppName'), 'web')]",
             "properties": {
                 "repoUrl": "[variables('repoUrl')]",
-                "branch": "main",
+                "branch": "personal/v-shnarang/maxcount",
                 "isManualIntegration": true
             },
             "dependsOn": [

--- a/src/ApiForFhirMigrationTool.Function/Configuration/MigrationOptions.cs
+++ b/src/ApiForFhirMigrationTool.Function/Configuration/MigrationOptions.cs
@@ -115,6 +115,12 @@ namespace ApiForFhirMigrationTool.Function.Configuration
         [JsonProperty("isExportDeidentified")]
         public bool IsExportDeidentified { get; set; } = false;
 
+        [JsonProperty("maxCount")]
+        public bool MaxCount { get; set; } = false;
+
+        [JsonProperty("maxCountValue")]
+        public int MaxCountValue { get; set; }
+
         [JsonProperty("configFile")]
         public string ConfigFile { get; set; } = string.Empty;
 

--- a/src/ApiForFhirMigrationTool.Function/ExportOrchestrator.cs
+++ b/src/ApiForFhirMigrationTool.Function/ExportOrchestrator.cs
@@ -432,8 +432,13 @@ public class ExportOrchestrator
 
         logger?.LogInformation("Query for the export operation retrieved successfully.");
 
-
-        return $"{setUrl}&{query}";
+        if (_options.MaxCount == true)
+        { 
+            var maxValue = _options.MaxCountValue == 0 ? 10000 : _options.MaxCountValue;
+            return $"{setUrl}&{query}&_maxCount={maxValue.ToString()}";
+        }
+        else
+            return $"{setUrl}&{query}";
     }
 
     private async Task<DateTimeOffset> SinceDate()


### PR DESCRIPTION
## Description
This PR addresses the addition of the _maxCount parameter in the export query to resolve memory-related export failures.
Updates:
1. ARM and Bicep Templates: Updated to include the _maxCount parameter.
2. Documentation: Enhanced with instructions on how to configure _maxCount in the data migration tool to ensure smoother export operations.
This enhancement provides a configurable option to mitigate memory issues during the export process.

## Related issues
Addresses [issue #133564](https://microsofthealth.visualstudio.com/Health/_workitems/edit/133564).

## Testing
Testing is done on Azure and export have the _maxCount value during migration