### PR TITLE
Versioned data not getting included while using data migration tool

### DIFF
--- a/infra/main.json
+++ b/infra/main.json
@@ -399,7 +399,7 @@
             "name": "[format('{0}/{1}', variables('functionAppName'), 'web')]",
             "properties": {
                 "repoUrl": "[variables('repoUrl')]",
-                "branch": "main",
+                "branch": "personal/shanarang/historyfix",
                 "isManualIntegration": true
             },
             "dependsOn": [

--- a/infra/main.json
+++ b/infra/main.json
@@ -399,7 +399,7 @@
             "name": "[format('{0}/{1}', variables('functionAppName'), 'web')]",
             "properties": {
                 "repoUrl": "[variables('repoUrl')]",
-                "branch": "personal/shanarang/historyfix",
+                "branch": "main",
                 "isManualIntegration": true
             },
             "dependsOn": [

--- a/src/ApiForFhirMigrationTool.Function/ExportOrchestrator.cs
+++ b/src/ApiForFhirMigrationTool.Function/ExportOrchestrator.cs
@@ -456,7 +456,7 @@ public class ExportOrchestrator
         var request = new HttpRequestMessage
         {
             Method = HttpMethod.Get,
-            RequestUri = new Uri(baseUri, "/?_sort=_lastUpdated&_count=1"),
+            RequestUri = _options.ExportWithHistory || _options.ExportWithDelete ? new Uri(baseUri, "/_history?_sort=_lastUpdated&_count=1") : new Uri(baseUri, "/?_sort=_lastUpdated&_count=1"),
         };
         HttpResponseMessage srcTask = await _fhirClient.Send(request, baseUri, sourceFhirEndpoint);
 


### PR DESCRIPTION
## Description
This PR addresses the issue of migration start date selection when the end user does not provide a start date and the "with history" option is enabled.
With this update, the migration tool now correctly determines the start date based on the oldest available FHIR resource, including versioned (historical) resources.

## Related issues
Addresses [issue #150547](https://microsofthealth.visualstudio.com/Health/_backlogs/backlog/Embers/Features?workitem=150547).

## Testing
We have tested the changes on Azure with history and without history enabled and now the migration tool now correctly determines the start date.