### PR TITLE
option to continue the last import after pausing the migration tool when using "stop data migration tool during business hours"

### DIFF
--- a/FHIR-data-migration-tool-docs/README.md
+++ b/FHIR-data-migration-tool-docs/README.md
@@ -322,7 +322,7 @@ Take a look at the screenshot below to learn how to configure the export setting
 
 ### Stop Data Migration Tool During Business Hours
 
-The migration tool allows you to specify a time frame during which no new export operations will start. By setting a time frame, you can ensure that new exports do not begin during business hours, while still allowing ongoing exports to complete and new exports to start after the specified time frame ends.
+The migration tool allows you to specify a time frame during which no new export/import operations will start. By setting a time frame, you can ensure that new exports/imports do not begin during business hours, while still allowing ongoing exports/imports to complete and new exports/imports to start after the specified time frame ends.
 
 During the deployment of the migration tool, you will have the option to enable or disable "Stop Migration Tool During Business Hours" by specifying its value as true or false. If you select true, you will also need to enter the start time and end time for the restricted period  in UTC. By default, the start time is set to 8 and the end time is set to 17.
 
@@ -347,6 +347,22 @@ Value: 9
 Name: AZURE_EndTime
 Value: 18
 ``` 
+#### Run the import job during business hours while migration tool is stopped.
+
+There is a parameter named:AZURE_ContinueLastImportDuringPause in the migration tool that allows the import job to run for an export job that is completed during business hours while the migration tool is stopped.
+
+For example, if an export job is running when the migration tool is stopped, the export will continue to run. However, once it is completed, the import job will not start automatically because the tool is in a stopped state. By using this parameter, you can enable the import job to start for any export job that completes during the stopped period.
+
+You can specify the following values within the Azure function's environment variables
+
+Example:
+```
+Name: AZURE_ContinueLastImportDuringPause
+Value: True
+```
+
+__Note__: No new export jobs will start during business hours when the migration tool is stopped. This parameter only allows import jobs to run for export jobs that finish while the migration tool is in a stopped state.
+
 ### Run Data Migration Tool During Specific Date Range
 
 The migration tool allows you to specify a time range for a predefined set of data. By configuring a time frame, you can ensure that only the data within that specific period will be migrated. 

--- a/src/ApiForFhirMigrationTool.Function/Configuration/MigrationOptions.cs
+++ b/src/ApiForFhirMigrationTool.Function/Configuration/MigrationOptions.cs
@@ -118,6 +118,9 @@ namespace ApiForFhirMigrationTool.Function.Configuration
         [JsonProperty("maxCount")]
         public bool MaxCount { get; set; } = false;
 
+        [JsonProperty("continueLastImportDuringPause")]
+        public bool ContinueLastImportDuringPause { get; set; } = false;
+
         [JsonProperty("maxCountValue")]
         public int MaxCountValue { get; set; }
 


### PR DESCRIPTION
## Description
This change is for using the option "Stop Data Migration Tool during business hours". The option called is "ContinueLastImportDuringPause'. Default should be OFF (current behavior) and then option ON would mean that if the migration tool is paused during an export, that export will still be imported into gen 2 during the paused time.

## Related issues
Addresses [issue #152433](https://microsofthealth.visualstudio.com/Health/_backlogs/backlog/Embers/Features?workitem=152433).

## Testing
Tested locally and on azure