### PR TITLE
Change "stop migration tool during business hours" to "pause"

### DIFF
--- a/FHIR-data-migration-tool-docs/README.md
+++ b/FHIR-data-migration-tool-docs/README.md
@@ -320,21 +320,21 @@ Take a look at the screenshot below to learn how to configure the export setting
 ![De-Identified](images/Export-with-history-and-delete-deidentified.png)
 
 
-### Stop Data Migration Tool During Business Hours
+### Pause Data Migration Tool During Business Hours
 
 The migration tool allows you to specify a time frame during which no new export/import operations will start. By setting a time frame, you can ensure that new exports/imports do not begin during business hours, while still allowing ongoing exports/imports to complete and new exports/imports to start after the specified time frame ends.
 
-During the deployment of the migration tool, you will have the option to enable or disable "Stop Migration Tool During Business Hours" by specifying its value as true or false. If you select true, you will also need to enter the start time and end time for the restricted period  in UTC. By default, the start time is set to 8 and the end time is set to 17.
+During the deployment of the migration tool, you will have the option to enable or disable "Pause Migration Tool During Business Hours" by specifying its value as true or false. If you select true, you will also need to enter the start time and end time for the restricted period  in UTC. By default, the start time is set to 8 and the end time is set to 17.
 
-Take a look at the screenshot below to learn how to configure these settings. By default, the value of "Stop Migration Tool During Business Hours" is set to false. If you prefer to stop the migration tool during business hours, you can change the value to true and specify the start time and end time in a 24-hour format format in UTC.<br>
+Take a look at the screenshot below to learn how to configure these settings. By default, the value of "Pause Migration Tool During Business Hours" is set to false. If you prefer to pause the migration tool during business hours, you can change the value to true and specify the start time and end time in a 24-hour format format in UTC.<br>
 
 ![StopDM](images/Stop-Data-MigrationTool.png)
 
-Upon the completion of deployment, you can still make adjustments to the export settings to stop the migration tool by modifying the values within the Azure function's environment variables.
+Upon the completion of deployment, you can still make adjustments to the export settings to pause the migration tool by modifying the values within the Azure function's environment variables.
 
 Example:
 ```
-Name: AZURE_StopDm
+Name: AZURE_PauseDm
 Value: True
 ```
 You can also specify the start and end times for the restricted period. For example, if you do not want new exports to start between 09:00 AM and 06:00 PM, modify the following values within the Azure function's environment variables
@@ -347,11 +347,11 @@ Value: 9
 Name: AZURE_EndTime
 Value: 18
 ``` 
-#### Run the import job during business hours while migration tool is stopped.
+#### Run the import job during business hours while migration tool is paused.
 
-There is a parameter named:AZURE_ContinueLastImportDuringPause in the migration tool that allows the import job to run for an export job that is completed during business hours while the migration tool is stopped.
+There is a parameter named:AZURE_ContinueLastImportDuringPause in the migration tool that allows the import job to run for an export job that is completed during business hours while the migration tool is paused.
 
-For example, if an export job is running when the migration tool is stopped, the export will continue to run. However, once it is completed, the import job will not start automatically because the tool is in a stopped state. By using this parameter, you can enable the import job to start for any export job that completes during the stopped period.
+For example, if an export job is running when the migration tool is paused, the export will continue to run. However, once it is completed, the import job will not start automatically because the tool is in a paused state. By using this parameter, you can enable the import job to start for any export job that completes during the paused period.
 
 You can specify the following values within the Azure function's environment variables
 
@@ -361,7 +361,7 @@ Name: AZURE_ContinueLastImportDuringPause
 Value: True
 ```
 
-__Note__: No new export jobs will start during business hours when the migration tool is stopped. This parameter only allows import jobs to run for export jobs that finish while the migration tool is in a stopped state.
+__Note__: No new export jobs will start during business hours when the migration tool is paused. This parameter only allows import jobs to run for export jobs that finish while the migration tool is in a paused state.
 
 ### Run Data Migration Tool During Specific Date Range
 

--- a/FHIR-data-migration-tool-docs/disaster-recovery.md
+++ b/FHIR-data-migration-tool-docs/disaster-recovery.md
@@ -293,21 +293,21 @@ Take a look at the screenshot below to learn how to configure the export setting
 ![De-Identified](images/Export-with-history-and-delete-deidentified.png)
 
 
-### Stop Data Migration Tool During Business Hours
+### Pause Data Migration Tool During Business Hours
 
 The migration tool allows you to specify a time frame during which no new export operations will start. By setting a time frame, you can ensure that new exports do not begin during business hours, while still allowing ongoing exports to complete and new exports to start after the specified time frame ends.
 
-During the deployment of the migration tool, you will have the option to enable or disable "Stop Migration Tool During Business Hours" by specifying its value as true or false. If you select true, you will also need to enter the start time and end time for the restricted period  in UTC. By default, the start time is set to 8 and the end time is set to 17.
+During the deployment of the migration tool, you will have the option to enable or disable "Pause Migration Tool During Business Hours" by specifying its value as true or false. If you select true, you will also need to enter the start time and end time for the restricted period  in UTC. By default, the start time is set to 8 and the end time is set to 17.
 
-Take a look at the screenshot below to learn how to configure these settings. By default, the value of "Stop Migration Tool During Business Hours" is set to false. If you prefer to stop the migration tool during business hours, you can change the value to true and specify the start time and end time in a 24-hour format format in UTC.<br>
+Take a look at the screenshot below to learn how to configure these settings. By default, the value of "Pause Migration Tool During Business Hours" is set to false. If you prefer to pause the migration tool during business hours, you can change the value to true and specify the start time and end time in a 24-hour format format in UTC.<br>
 
 ![StopDM](images/Stop-Data-MigrationTool.png)
 
-Upon the completion of deployment, you can still make adjustments to the export settings to stop the migration tool by modifying the values within the Azure function's environment variables.
+Upon the completion of deployment, you can still make adjustments to the export settings to pause the migration tool by modifying the values within the Azure function's environment variables.
 
 Example:
 ```
-Name: AZURE_StopDm
+Name: AZURE_PauseDm
 Value: True
 ```
 You can also specify the start and end times for the restricted period. For example, if you do not want new exports to start between 09:00 AM and 06:00 PM, modify the following values within the Azure function's environment variables

--- a/infra/ARMmain.parameters.json
+++ b/infra/ARMmain.parameters.json
@@ -44,7 +44,7 @@
         "configFile":{
             "value": ""
         },
-        "stopDm":{
+        "pauseDm":{
             "value": false
         },
         "specificRun":{

--- a/infra/azureFunction.bicep
+++ b/infra/azureFunction.bicep
@@ -18,7 +18,7 @@ param exportWithDelete bool
 param isParallel bool
 param exportDeidentified bool
 param configFile string
-param stopDm bool
+param pauseDm bool
 param startTime int
 param endTime int
 param specificRun bool
@@ -137,7 +137,7 @@ resource functionApp 'Microsoft.Web/sites@2021-03-01' = {
               AZURE_MaxCount: 'false'
               AZURE_MaxCountValue: 10000
               AZURE_ExportDeidentified:exportDeidentified
-              AZURE_StopDm:stopDm
+              AZURE_PauseDm:pauseDm
               AZURE_StartTime:startTime
               AZURE_EndTime:endTime
               AZURE_SpecificRun: specificRun

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -58,7 +58,7 @@ param exportDeidentified bool
 param configFile string = ''
 
 @description('Export by timestamp')
-param stopDm bool
+param pauseDm bool
 
 @description('Indicates the start time for the hours when export and import operations are restricted')
 param startTime int = 8
@@ -153,7 +153,7 @@ module function './azureFunction.bicep'= {
         exportWithDelete : exportWithDelete
         isParallel :isParallel
         exportDeidentified:exportDeidentified
-        stopDm:stopDm
+        pauseDm:pauseDm
         startTime:startTime
         endTime:endTIme
         specificRun: specificRun

--- a/infra/main.json
+++ b/infra/main.json
@@ -399,7 +399,7 @@
             "name": "[format('{0}/{1}', variables('functionAppName'), 'web')]",
             "properties": {
                 "repoUrl": "[variables('repoUrl')]",
-                "branch": "personal/shanarang/updatekeywords",
+                "branch": "main",
                 "isManualIntegration": true
             },
             "dependsOn": [

--- a/infra/main.json
+++ b/infra/main.json
@@ -144,7 +144,7 @@
                 "description": "Name of Configuration file"
             }
         },
-        "stopDm":{
+        "pauseDm":{
             "type": "bool",
             "defaultValue": false,
             "metadata": {
@@ -368,7 +368,7 @@
                 "AZURE_MaxCount": false,
                 "AZURE_MaxCountValue": 10000,
                 "AZURE_ExportDeidentified":"[parameters('exportDeidentified')]",
-                "AZURE_StopDm":"[parameters('stopDm')]",
+                "AZURE_PauseDm":"[parameters('pauseDm')]",
                 "AZURE_StartTime":"[parameters('startTime')]",
                 "AZURE_EndTime":"[parameters('endTime')]",
                 "AZURE_SpecificRun":"[parameters('specificRun')]",

--- a/infra/main.json
+++ b/infra/main.json
@@ -399,7 +399,7 @@
             "name": "[format('{0}/{1}', variables('functionAppName'), 'web')]",
             "properties": {
                 "repoUrl": "[variables('repoUrl')]",
-                "branch": "main",
+                "branch": "personal/shanarang/updatekeywords",
                 "isManualIntegration": true
             },
             "dependsOn": [

--- a/infra/uiDefForm.json
+++ b/infra/uiDefForm.json
@@ -286,9 +286,9 @@
                                
                             },
                             {
-                                "name": "stopMigrationDuringBusinessHours",
+                                "name": "pauseMigrationDuringBusinessHours",
                                 "type": "Microsoft.Common.DropDown",
-                                "label": "Stop Data Migration Tool During Business Hours",
+                                "label": "Pause Data Migration Tool During Business Hours",
                                 "defaultValue":"False",
                                 "toolTip": "The migration tool lets you set a time frame to prevent new export operations during business hours, while ongoing exports will continue and new ones will start after the restricted period. ",
                                 "constraints": {
@@ -307,9 +307,9 @@
                                 "visible": true
                             },
                             {
-                                "name": "stopDmInfoBox",
+                                "name": "pauseDmInfoBox",
                                 "type": "Microsoft.Common.InfoBox",
-                                "visible": "[steps('fhirSelection').fhirSection.stopMigrationDuringBusinessHours]",
+                                "visible": "[steps('fhirSelection').fhirSection.pauseMigrationDuringBusinessHours]",
                                 "options": {
                                     "icon": "Info",
                                     "text": "You need to enter the start and end times in a 24-hour format in UTC for the restricted period. \nBy default, the start time is set to 8 and the end time is set to 17 UTC.\nFor example, if you do not want new exports to start between 09:00 AM and 06:00 PM UTC, enter 9 as the start time and 18 as the end time."
@@ -322,11 +322,11 @@
                                 "placeholder": "Enter Start Time",
                                 "defaultValue": 8,
                                 "dependsOn": [
-                                    "[steps('fhirSelection').fhirSection.stopMigrationDuringBusinessHours]"
+                                    "[steps('fhirSelection').fhirSection.pauseMigrationDuringBusinessHours]"
                                 ],
-                                "visible": "[steps('fhirSelection').fhirSection.stopMigrationDuringBusinessHours]",
+                                "visible": "[steps('fhirSelection').fhirSection.pauseMigrationDuringBusinessHours]",
                                 "constraints": {
-                                    "required": "[steps('fhirSelection').fhirSection.stopMigrationDuringBusinessHours]",
+                                    "required": "[steps('fhirSelection').fhirSection.pauseMigrationDuringBusinessHours]",
                                     "regex": "^[0-9]{1,2}$",
                                     "validationMessage": "Hour must be an integer between 0 and 23",
                                     "minValue": 0,
@@ -340,11 +340,11 @@
                                 "placeholder": "Enter End Time",
                                 "defaultValue": 17,
                                 "dependsOn": [
-                                    "[steps('fhirSelection').fhirSection.stopMigrationDuringBusinessHours]"
+                                    "[steps('fhirSelection').fhirSection.pauseMigrationDuringBusinessHours]"
                                 ],
-                                "visible": "[steps('fhirSelection').fhirSection.stopMigrationDuringBusinessHours]",
+                                "visible": "[steps('fhirSelection').fhirSection.pauseMigrationDuringBusinessHours]",
                                 "constraints": {
-                                    "required": "[steps('fhirSelection').fhirSection.stopMigrationDuringBusinessHours]",
+                                    "required": "[steps('fhirSelection').fhirSection.pauseMigrationDuringBusinessHours]",
                                     "regex": "^[0-9]{1,2}$",
                                     "validationMessage": "Hour must be an integer between 0 and 23",
                                     "minValue": 0,
@@ -430,7 +430,7 @@
             "isParallel":"[steps('fhirSelection').fhirSection.isParallel]",
             "exportDeidentified":"[steps('fhirSelection').fhirSection.exportDeidentified]",
             "configFile":"[steps('fhirSelection').fhirSection.configurationFile]",
-            "stopDm":"[steps('fhirSelection').fhirSection.stopMigrationDuringBusinessHours]",
+            "pauseDm":"[steps('fhirSelection').fhirSection.pauseMigrationDuringBusinessHours]",
             "startTime": "[int(steps('fhirSelection').fhirSection.startTime)]",
             "endTime": "[int(steps('fhirSelection').fhirSection.endTime)]",
             "specificRun":"[steps('fhirSelection').fhirSection.MigrationDuringSpecificRange]",

--- a/src/ApiForFhirMigrationTool.Function/Configuration/MigrationOptions.cs
+++ b/src/ApiForFhirMigrationTool.Function/Configuration/MigrationOptions.cs
@@ -287,8 +287,8 @@ namespace ApiForFhirMigrationTool.Function.Configuration
         [JsonProperty("fileCount")]
         public int FileCount { get; set; } = 10000;
 
-        [JsonProperty("stopDm")]
-        public bool StopDm { get; set; } = false;
+        [JsonProperty("pauseDm")]
+        public bool PauseDm { get; set; } = false;
 
         [JsonProperty("specificRun")]
         public bool SpecificRun { get; set; } = false;

--- a/src/ApiForFhirMigrationTool.Function/MigrationOrchestrator.cs
+++ b/src/ApiForFhirMigrationTool.Function/MigrationOrchestrator.cs
@@ -54,7 +54,7 @@ namespace ApiForFhirMigrationTool.Function
                 bool shouldRun = true;
                 bool continueRun = true;
 
-                if (_options.StopDm)
+                if (_options.PauseDm)
                 {
                     if (_options.StartTime < 0 || _options.StartTime > 23 || _options.EndTime < 0 || _options.EndTime > 23)
                     {
@@ -174,7 +174,7 @@ namespace ApiForFhirMigrationTool.Function
                     }
                     else if (_options.ContinueLastImportDuringPause)
                     {
-                        //Only run export status and import activity to process any completed export after the tool stopped.
+                        //Only run export status and import activity to process any completed export after the tool paused.
 
                         //Run sub orchestration for export status
                         logger.LogInformation("Starting Export Status activities");


### PR DESCRIPTION
## Description
The PR update the keyword "stop" migration tool during business hours to "pause" migration tool during business hours

## Related issues
Addresses [issue #153761](https://microsofthealth.visualstudio.com/Health/_workitems/edit/153761).

## Testing
The changes tested locally and Azure Portal